### PR TITLE
include shared schemes to the template

### DIFF
--- a/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/xcshareddata/xcschemes/__PROJECT NAME__ debug.xcscheme
+++ b/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/xcshareddata/xcschemes/__PROJECT NAME__ debug.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2112D308205F70A200288FD9"
+               BuildableName = "__PROJECT NAME__.app"
+               BlueprintName = "__PROJECT NAME__"
+               ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2112D31C205F70A200288FD9"
+               BuildableName = "__PROJECT NAME__Tests.xctest"
+               BlueprintName = "__PROJECT NAME__Tests"
+               ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2112D327205F70A200288FD9"
+               BuildableName = "__PROJECT NAME__UITests.xctest"
+               BlueprintName = "__PROJECT NAME__UITests"
+               ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/xcshareddata/xcschemes/__PROJECT NAME__ staging.xcscheme
+++ b/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/xcshareddata/xcschemes/__PROJECT NAME__ staging.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2112D308205F70A200288FD9"
+               BuildableName = "__PROJECT NAME__.app"
+               BlueprintName = "__PROJECT NAME__"
+               ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Staging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2112D31C205F70A200288FD9"
+               BuildableName = "__PROJECT NAME__Tests.xctest"
+               BlueprintName = "__PROJECT NAME__Tests"
+               ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2112D327205F70A200288FD9"
+               BuildableName = "__PROJECT NAME__UITests.xctest"
+               BlueprintName = "__PROJECT NAME__UITests"
+               ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Staging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Staging"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Staging">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Staging"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/xcshareddata/xcschemes/__PROJECT NAME__.xcscheme
+++ b/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/xcshareddata/xcschemes/__PROJECT NAME__.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2112D308205F70A200288FD9"
+               BuildableName = "__PROJECT NAME__.app"
+               BlueprintName = "__PROJECT NAME__"
+               ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2112D308205F70A200288FD9"
+            BuildableName = "__PROJECT NAME__.app"
+            BlueprintName = "__PROJECT NAME__"
+            ReferencedContainer = "container:__PROJECT NAME__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
I created shared schemes for our 3 build configurations. This includes:
```
- __PROJECT NAME__
- __PROJECT NAME__ staging
- __PROJECT NAME__ debug
```
the first scheme is set with `release` configuration and doesn't include testing in the scheme. The others are as its name says, with testing included.

This closes #12 