### PR TITLE
Set Export dSYM for all Target

### DIFF
--- a/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/project.pbxproj
+++ b/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "__PROJECT NAME__/Application/Infos/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
For sending `Debug` target to crashlytics, we need to send dSYM with it. So this is require in build setting. 

<img src="https://i.imgur.com/gpFpT05.png" />

will close #20 