### PR TITLE
Support Crashlytics and Fabric Beta

### DIFF
--- a/__PROJECT NAME__/Podfile
+++ b/__PROJECT NAME__/Podfile
@@ -10,6 +10,8 @@ target '__PROJECT NAME__' do
   use_frameworks!
 
   pod 'Alamofire'
+  pod 'Fabric'
+  pod 'Crashlytics'
 
   target '__PROJECT NAME__Tests' do
     inherit! :search_paths

--- a/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/project.pbxproj
+++ b/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 				2112D305205F70A200288FD9 /* Sources */,
 				2112D306205F70A200288FD9 /* Frameworks */,
 				2112D307205F70A200288FD9 /* Resources */,
+				215BF30C206CD80600ADDB06 /* Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -323,6 +324,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		215BF30C206CD80600ADDB06 /* Crashlytics */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 12;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Crashlytics;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Fabric/run\" __CRASHLYTICS-API-KEY__ __CRASHLYTICS-BUILD-SECRET__";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2112D305205F70A200288FD9 /* Sources */ = {

--- a/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/project.pbxproj
+++ b/__PROJECT NAME__/__PROJECT NAME__.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Fabric/run\" __CRASHLYTICS-API-KEY__ __CRASHLYTICS-BUILD-SECRET__";
+			shellScript = "\"${PODS_ROOT}/Fabric/run\" __CRASHLYTICS_API_TOKEN__ __CRASHLYTICS_BUILD_SECRET__";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/__PROJECT NAME__/__PROJECT NAME__/Application/AppDelegate.swift
+++ b/__PROJECT NAME__/__PROJECT NAME__/Application/AppDelegate.swift
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+import Fabric
+import Crashlytics
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,6 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        Fabric.with([Crashlytics.self])
+        
         if (window == nil) {
             window = UIWindow(frame: UIScreen.main.bounds)
         }

--- a/__PROJECT NAME__/__PROJECT NAME__/Application/Infos/Info.plist
+++ b/__PROJECT NAME__/__PROJECT NAME__/Application/Infos/Info.plist
@@ -21,7 +21,7 @@
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>
-		<string>__CRASHLYTICS-API-KEY__</string>
+		<string>__CRASHLYTICS_API_TOKEN__</string>
 		<key>Kits</key>
 		<array>
 			<dict>

--- a/__PROJECT NAME__/__PROJECT NAME__/Application/Infos/Info.plist
+++ b/__PROJECT NAME__/__PROJECT NAME__/Application/Infos/Info.plist
@@ -18,6 +18,20 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>Fabric</key>
+	<dict>
+		<key>APIKey</key>
+		<string>__CRASHLYTICS-API-KEY__</string>
+		<key>Kits</key>
+		<array>
+			<dict>
+				<key>KitInfo</key>
+				<dict/>
+				<key>KitName</key>
+				<string>Crashlytics</string>
+			</dict>
+		</array>
+	</dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
I configured project file to support Crashlytics and Fabric in our template project. Added them into our `podfile`, and also updated the Bakery script, which now supports automatic Cocoapods installation right after project generation. ✌🏻