### PR TITLE
ensure remove - from app name

### DIFF
--- a/__PROJECT NAME__/fastlane/Developer Portal/Codefile
+++ b/__PROJECT NAME__/fastlane/Developer Portal/Codefile
@@ -64,7 +64,7 @@ platform :ios do
     produce(
       username: "#{ENV['APPLE_ID']}",
       app_identifier: options[:app_identifier],
-      app_name: options[:app_name],
+      app_name: options[:app_name].gsub("-", " "),
       language: options[:language] || "English",
       app_version: options[:app_version] || "1.0",
       sku: options[:sku],


### PR DESCRIPTION
Apple developer portal doesn't support to create app id `name` with `-`. 

So I add gsub `ruby`  in fastlane to replace `-` with ` ` ( space ). 

#32 