### PR TITLE
Ignore .DS_Store and p12

### DIFF
--- a/__PROJECT NAME__/.gitignore
+++ b/__PROJECT NAME__/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+# MacOS
+.DS_Store
+
 ## Build generated
 build/
 derivedData/

--- a/__PROJECT NAME__/.gitignore
+++ b/__PROJECT NAME__/.gitignore
@@ -34,6 +34,7 @@ xcuserdata/
 ## Code Signing
 *.cer
 *.mobileprovision
+*.p12
 
 ## Playgrounds
 timeline.xctimeline


### PR DESCRIPTION
### Description
- `.DS_Store` always added as untracked file while working on the repository.
- `.p12` was added after `cert` and `sigh` which shouldn't commit to repository with unencrypted.

### Insight 
- I added `.DS_Store` and `.p12` to git ignore file.

close #35 