### PR TITLE
Create AppID helper lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ ROOT
   - Integrate UI and unit test
 
 #### Code Signing
+  - AppID
+    - AppIDs can be created automatically with `lane :create_app_ids`, this will create AppIDs for `Appstore`, `Staging` and `Debug` schemes.
+  - App Store Connect 
+    - App in App Store Connect needs to be created manually. 
   - Certificate
     - Development
       - for DEBUG build configuration.

--- a/__PROJECT NAME__/fastlane/Developer Portal/Codefile
+++ b/__PROJECT NAME__/fastlane/Developer Portal/Codefile
@@ -80,21 +80,27 @@ platform :ios do
   end
 
   desc "create App ID for all app bundles"
-  lane :create_app_ids do
+  lane :create_app_ids do |options|
     ## DEBUG
     create_app_on_developer_portal(
       app_identifier: "#{ENV["BUNDLE_ID_DEBUG"]}",
       app_name: "#{ENV["SCHEME_NAME_DEBUG"]}",
+      sku: options[:sku],
+      team_name: options[:team_name],
     )
     ## STAGING
     create_app_on_developer_portal(
       app_identifier: "#{ENV["BUNDLE_ID_STAGING"]}",
       app_name: "#{ENV["SCHEME_NAME_STAGING"]}",
+      sku: options[:sku],
+      team_name: options[:team_name],
     )
     ## RELEASE
     create_app_on_developer_portal(
       app_identifier: "#{ENV["BUNDLE_ID"]}",
       app_name: "#{ENV["SCHEME_NAME"]}",
+      sku: options[:sku],
+      team_name: options[:team_name],
     )
   end
 

--- a/__PROJECT NAME__/fastlane/Developer Portal/Codefile
+++ b/__PROJECT NAME__/fastlane/Developer Portal/Codefile
@@ -78,4 +78,37 @@ platform :ios do
       )
     end
   end
+
+  desc "create App ID for all app bundles"
+  lane :create_app_ids do
+    ## DEBUG
+    create_app_on_developer_portal(
+      app_identifier: "#{ENV["BUNDLE_ID_DEBUG"]}",
+      app_name: "#{ENV["SCHEME_NAME_DEBUG"]}",
+    )
+    ## STAGING
+    create_app_on_developer_portal(
+      app_identifier: "#{ENV["BUNDLE_ID_STAGING"]}",
+      app_name: "#{ENV["SCHEME_NAME_STAGING"]}",
+    )
+    ## RELEASE
+    create_app_on_developer_portal(
+      app_identifier: "#{ENV["BUNDLE_ID"]}",
+      app_name: "#{ENV["SCHEME_NAME"]}",
+    )
+  end
+
+  desc "create App ID for all app bundles."
+  private_lane :create_app_on_developer_portal do |options|
+    produce(
+      username: "#{ENV["APPLE_ID"]}",
+      app_identifier: options[:app_identifier],
+      app_name: options[:app_name].gsub("-", " "),
+      language: options[:language] || "English",
+      app_version: options[:app_version] || "1.0",
+      sku: options[:sku],
+      team_name: options[:team_name],
+      skip_itc: true,
+    )
+  end
 end


### PR DESCRIPTION
### What's Happened ###
- After setup the project, then we need the app id for code signing 

## Insight ### 
- These lanes will create AppID on `Developer portal` with project name that set. 