### PR TITLE
[#70] Add issue and pr template file

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Bug report
+
+Provide a brief summary of your issue **AND** if reporting a build issue include the version/build number.
+
+## Feature request
+
+Provide a brief summary of the new feature required.
+
+**Please note by far the quickest way to get a new feature is to file a Pull Request.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+https://github.com/nimble/git-template/issues/??
+
+## What happened
+
+Describe the big picture of your changes here to communicate to the team why we should accept this pull request. 
+ 
+## Insight
+
+Describe in details how to test the changes; referenced documentation is welcome as well.
+ 
+## Proof Of Work
+
+Show us the implementation: screenshots, gif, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-https://github.com/nimble/git-template/issues/??
+https://github.com/nimbl3/ios-templates/issues/
 
 ## What happened
 


### PR DESCRIPTION
https://github.com/nimble/git-templates/issues/70

## What happened
- We have no template file for pull request and issue creation yet. 
 
## Insight
- add template file 

close #70 