### PR TITLE
[#69] Invalid keychain name on ci machine. 

### DIFF
--- a/__PROJECT NAME__/fastlane/.env
+++ b/__PROJECT NAME__/fastlane/.env
@@ -6,6 +6,12 @@ XCWORKSPACE="${PROJECT_NAME}.xcworkspace"
 XCODE_PROJ="${PROJECT_NAME}.xcodeproj"
 
 ################
+## REPOSITORY
+################
+REPOSITORY_NAME="__REPOSITORY_NAME__"
+# FIRST_COMMIT_HASH=""
+
+################
 ## APPSTORE
 ################
 APPLE_ID="__APPLE_ID__"
@@ -58,12 +64,6 @@ KEYCHAIN_NAME="${REPOSITORY_NAME}"
 ################
 PT_PROJECT_ID="__PT_PROJECT_ID__"
 PT_PROJECT_TOKEN="__PT_PROJECT_TOKEN__"
-
-################
-## REPOSITORY
-################
-REPOSITORY_NAME="__REPOSITORY_NAME__"
-# FIRST_COMMIT_HASH=""
 
 ################
 ## BITBUCKET


### PR DESCRIPTION
https://github.com/nimbl3/ios-templates/issues/69

## What happened
- Fastlane generated keychain on ci with `-${BRANCH_NAME}`
- The expected name is `${REPOSITORY_NAME}-${BRANCH_NAME}` 

## Insight
- `REPOSITORY_NAME` is invalid order, it's used before define this env variable.  

close #73 
