### PR TITLE
[#79] change keyword `ci-skip` to `skip-ci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,19 @@ ROOT
     - **Debug** for development - _with `DEBUG` flag defined_
     - **Release** for releasing to App Store - _with `RELEASE` flag defined_
     - **Staging** for releasing beta - _with `STAGING` flag defined_
-  - Schemes setup:
-    - **_{Project name}_** - with _release_ configuration without tests
-    - **_{Project name}_ debug** - with _debug_ configuration and tests included
-    - **_{Project name}_ staging** - with _staging_ configuration and tests included
-  - Set _Defines module_ to `YES` for enabling Quick & Nimble test module.
+
+  - Schemes:
+    - This project is set up with 6 schemes as listed below:
+      - **{Project name}** - targeted at production level for releasing to App Store.
+      - **{Project name} staging** - set up for staging environment with Ad-hoc distribution provisioning profile for releasing beta to Crashlytics.
+      - **{Project name} debug** - set up for staging environment with development
+      provisioning profile for development and debugging. This scheme includes unit testing.
+      - **{Project name} test suite** - configured for both UI and unit tests. *This scheme is intended for Jenkins to build testing targets only once.*
+      - **{Project name} unit-tests** - configured for unit tests only.
+      - **{Project name} ui-tests** - configured for UI tests only.
+
+> When working on the project, usually **test suite** and **unit-tests** can be omitted as the former one is only meant for building testing targets, and unit tests are already includes in **debug** scheme for the latter one.
+
   - Add a run script for SwiftLint
   - Add a run script for Crashlytics
   - Integrate UI and unit test
@@ -106,7 +114,6 @@ More information on opted in/out Rules to come...
 
 #### Credentials Management 
  There're some environment variables required to be set up both on Local machine and Jenkins Master
-
   - **${PREFIX}**_CRASHLYTICS_API_TOKEN
   - **${PREFIX}**_CRASHLYTICS_BUILD_SECRET
   - **${PREFIX}**_MATCH_PASSWORD
@@ -121,3 +128,12 @@ More information on opted in/out Rules to come...
   - These variables need to be set on Jenkins with this following navigation. 
     - `Project > Credentials > Project's Scope > Add credentials`
   - All credentials can be passed as environment variables in Jenkinsfile using [Jenkins Credentials Binding](https://jenkins.io/doc/pipeline/steps/credentials-binding/)
+#### **Jenkins**
+
+Using `[skip-ci]` in commit message will make Jenkins skip every pipeline on the job.
+
+Using `[skip-deploy]` in commit message or pull request title will make Jenkins skip `Build for deploy` and `Deploy` steps. 
+
+**[Nimbl3's Jenkins](http://jenkins.nimbl3.com)** is configured with global shared library linking to `master` branch of [jenkins-shared-library](https://github.com/nimbl3/jenkins-pipeline-shared) repository.
+
+> Be cautious of the usage of `[skip-ci]` as, currently, it will make the job's result to `SUCCESS` all the time.

--- a/__PROJECT NAME__/Jenkinsfile
+++ b/__PROJECT NAME__/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'nimbl3-dev'
     GIT_COMMITTER_EMAIL = 'dev@nimbl3.com'
     IS_JENKINS = 'true'
+    COMMIT_MESSAGE = getCommitMessage()
   }
 
   stages {
@@ -22,7 +23,7 @@ pipeline {
     }
 
     stage('Setup CI') {
-      when { expression { doesNotContainCISkip() } }
+      when { not { expression { shouldSkipCI() } } } 
       steps {
         sh 'bundle install --path .bundle'
         sh 'bundle exec fastlane run setup_jenkins'
@@ -33,7 +34,7 @@ pipeline {
 
     stage('Linting') {
       when {
-        expression { doesNotContainCISkip() }
+        not { expression { shouldSkipCI() } }
         branch 'PR-*'
       }
 
@@ -50,21 +51,21 @@ pipeline {
     }
     
     stage('Build for testing') {
-      when { expression { doesNotContainCISkip() } }
+      when { not { expression { shouldSkipCI() } } }
       steps {
         sh 'bundle exec fastlane ci_build_for_testing'
       }
     }
 
     stage('Unit tests') {
-      when { expression { doesNotContainCISkip() } }
+      when { not { expression { shouldSkipCI() } } }
       steps {
         sh 'bundle exec fastlane ci_unit_tests'
       }
     }
 
     stage('Instrumented & UI tests') {
-      when { expression { doesNotContainCISkip() } }
+      when { not { expression { shouldSkipCI() } } }
       steps {
         script {
           if (currentBuild.result == null || currentBuild.result == 'SUCCESS') {
@@ -77,7 +78,8 @@ pipeline {
 
     stage('Build for deploy') {
       when {
-        expression { doesNotContainCISkip() }
+        not { expression { shouldSkipCI() } }
+        not { expression { shouldSkipDeploy() } }
         anyOf {
           branch 'develop'
           branch 'release/*'
@@ -113,7 +115,8 @@ pipeline {
 
     stage('Deploy') {
       when {
-        expression { doesNotContainCISkip() }
+        not { expression { shouldSkipCI() } }
+        not { expression { shouldSkipDeploy() } }
         anyOf {
           branch 'develop'
           branch 'release/*'
@@ -149,7 +152,10 @@ pipeline {
     }
 
     stage("Clean git status") {
-      when { expression { doesNotContainCISkip() } }
+      when {
+        not { expression { shouldSkipCI() } }
+        not { expression { shouldSkipDeploy() } }
+      }
       steps {
         sh 'bundle exec fastlane ci_clean_git_repository'
       }

--- a/__PROJECT NAME__/Jenkinsfile
+++ b/__PROJECT NAME__/Jenkinsfile
@@ -171,12 +171,3 @@ pipeline {
     }
   }
 }
-
-def doesNotContainCISkip() {
-  def containCISkip = sh (script: "git log -1 | grep '.*\\[ci-skip].*'", returnStatus: true)
-  if (containCISkip == 0) {
-    echo "'[ci-skip]' found in git latest commit message. Skipping"
-    return false
-  }
-  return true
-}

--- a/__PROJECT NAME__/fastlane/CI/CIfile
+++ b/__PROJECT NAME__/fastlane/CI/CIfile
@@ -143,7 +143,7 @@ platform :ios do
 
     create_bitbucket_pull_request(
       origin: current_branch,
-      title: pull_request_title,
+      title: "[skip-deploy]" + pull_request_title,
       destination: "develop",
       description: description,
     )

--- a/__PROJECT NAME__/fastlane/Fastfile
+++ b/__PROJECT NAME__/fastlane/Fastfile
@@ -1,7 +1,7 @@
 require("dotenv")
 Dotenv.load
 
-@bump_build_commit_message = "[ci-skip] bump build to"
+@bump_build_commit_message = "[skip-ci] bump build to"
 
 skip_docs
 
@@ -83,7 +83,7 @@ platform :ios do
     )
 
     commit_version_bump(
-      message: "[ci-skip] bump version to #{version_number}",
+      message: "[skip-ci] bump version to #{version_number}",
     )
 
     push_to_git_remote(
@@ -99,10 +99,12 @@ platform :ios do
     description.sub!("--story-id--", "#{story_id}")
     description.sub!("--version--", "#{version_number}")
 
-    create_bitbucket_pull_request(origin: bump_version_branch,
-                                  destination: "develop",
-                                  title: "[##{story_id}]  Update project version to #{version_number}",
-                                  description: description)
+    create_bitbucket_pull_request(
+      origin: bump_version_branch,
+      destination: "develop",
+      title: "[skip-ci][##{story_id}]  Update project version to #{version_number}",
+      description: description,
+    )
 
     sh "git checkout develop"
     sh "git branch -d -f #{bump_version_branch}"


### PR DESCRIPTION

## What happened
- I created shared Jenkins function on [jenkins-pipeline-shared](https://github.com/nimbl3/jenkins-pipeline-shared)
- Now we have `shouldSkipDeploy()`, `shouldSkipCI()`, `getCommitMessage()` `containsCommitMessage()` as helper function without importing. 

## Insight
- Update `ci-skip` to `skip-ci` because now we have `skip-deploy` so I rename `ci-skip` to `skip-ci` following deploy
- Remove Internal helper function.  

close #79 
